### PR TITLE
Return headers if $response->Body() is null

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -314,10 +314,12 @@ class Client
                 true
             );
         }
-        elseif ($contents = $response->getHeaders()) {
-                return $contents;
+
+        if ($contents = $response->getHeaders()) {
+             return $contents;
         }
-        return array();
+
+        return [];
     }
 
     /**


### PR DESCRIPTION
After creating a new ucgPost, we get some error, because $response->Body is null, but we still have to  parse the response, for getting the _X-RestLi-Id_ for storing our new publish.

