### PR TITLE
Add support for PUT in Client API

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -241,7 +241,7 @@ class AccessToken implements \JsonSerializable
     /**
      * Specify data format for json_encode()
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             'token' => $this->getToken(),

--- a/src/Client.php
+++ b/src/Client.php
@@ -601,14 +601,14 @@ class Client
      * Make API call to LinkedIn using PUT method
      *
      * @param string $endpoint
-     * @param array  $params
+     * @param resource $resource
      *
      * @return array
      * @throws \LinkedIn\Exception
      */
-    public function put($endpoint, array $params = [])
+    public function put($endpoint, $resource)
     {
-        if (false === is_resource($params['body'])) {
+        if (false === is_resource($resource)) {
             throw new \InvalidArgumentException(
                 sprintf('Argument must be a valid resource type. %s given.', gettype($resource))
             );
@@ -618,20 +618,15 @@ class Client
             (new GuzzleClient())->put(
                 $endpoint,
                 [
-                    array_merge(
-                        [
-                            'headers' => [
-                                'Authorization'  => 'Bearer ' . $this->accessToken->getToken()
-                            ]
-                        ],
-                        $params
-                    )
+                    'headers' => [
+                        'Authorization'  => 'Bearer ' . $this->accessToken->getToken()
+                    ],
+                    'body' => $resource
                 ]
             );
         } catch (RequestException $requestException) {
             throw Exception::fromRequestException($requestException);
         }
-
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -553,7 +553,7 @@ class Client
         } catch (RequestException $requestException) {
             throw Exception::fromRequestException($requestException);
         }
-        return ($method != Method::PUT) ? self::responseToArray($response) : [];
+        return self::responseToArray($response);
     }
 
     /**
@@ -608,7 +608,26 @@ class Client
      */
     public function put($endpoint, array $params = [])
     {
-        return $this->api($endpoint, $params, Method::PUT);
+        if (false === is_resource($params['body'])) {
+            throw new \InvalidArgumentException(
+                sprintf('Argument must be a valid resource type. %s given.', gettype($resource))
+            );
+        }
+
+        try {
+            (new GuzzleClient())->put(
+                $endpoint,
+                [
+                    'headers' => [
+                        'Authorization'  => 'Bearer ' . $this->accessToken->getToken()
+                    ],
+                    'body' => $resource
+                ]
+            );
+        } catch (RequestException $requestException) {
+            throw Exception::fromRequestException($requestException);
+        }
+
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -352,7 +352,7 @@ class Client
      */
     public static function responseToArray($response)
     {
-        if ($response->getHeaderLine('Content-Length') > 0 && ($contents = $response->getBody()->getContents())) {
+        if ($contents = $response->getBody()->getContents()) {
             return \GuzzleHttp\json_decode(
                 $contents,
                 true

--- a/src/Client.php
+++ b/src/Client.php
@@ -618,10 +618,14 @@ class Client
             (new GuzzleClient())->put(
                 $endpoint,
                 [
-                    'headers' => [
-                        'Authorization'  => 'Bearer ' . $this->accessToken->getToken()
-                    ],
-                    $params
+                    array_merge(
+                        [
+                            'headers' => [
+                                'Authorization'  => 'Bearer ' . $this->accessToken->getToken()
+                            ]
+                        ],
+                        $params
+                    )
                 ]
             );
         } catch (RequestException $requestException) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -352,7 +352,7 @@ class Client
      */
     public static function responseToArray($response)
     {
-        if ($contents = $response->getBody()->getContents()) {
+        if ($response->getHeaderLine('Content-Length') > 0 && ($contents = $response->getBody()->getContents())) {
             return \GuzzleHttp\json_decode(
                 $contents,
                 true

--- a/src/Client.php
+++ b/src/Client.php
@@ -598,6 +598,20 @@ class Client
     }
 
     /**
+     * Make API call to LinkedIn using PUT method
+     *
+     * @param string $endpoint
+     * @param array  $params
+     *
+     * @return array
+     * @throws \LinkedIn\Exception
+     */
+    public function put($endpoint, array $params = [])
+    {
+        return $this->api($endpoint, $params, Method::PUT);
+    }
+
+    /**
      * @param $path
      * @return array
      * @throws Exception

--- a/src/Client.php
+++ b/src/Client.php
@@ -553,7 +553,7 @@ class Client
         } catch (RequestException $requestException) {
             throw Exception::fromRequestException($requestException);
         }
-        return self::responseToArray($response);
+        return ($method != Method::PUT) ? self::responseToArray($response) : [];
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -621,7 +621,7 @@ class Client
                     'headers' => [
                         'Authorization'  => 'Bearer ' . $this->accessToken->getToken()
                     ],
-                    'body' => $resource
+                    $params
                 ]
             );
         } catch (RequestException $requestException) {

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -72,7 +72,7 @@ class Method extends AbstractEnum
      */
     public static function isMethodSupported($method)
     {
-        if (!in_array($method, [Method::GET, Method::POST, Method::DELETE])) {
+        if (!in_array($method, [Method::GET, Method::POST, Method::DELETE, Method::PUT])) {
             throw new \InvalidArgumentException('The method is not correct');
         }
     }

--- a/src/Http/Method.php
+++ b/src/Http/Method.php
@@ -72,7 +72,7 @@ class Method extends AbstractEnum
      */
     public static function isMethodSupported($method)
     {
-        if (!in_array($method, [Method::GET, Method::POST, Method::DELETE, Method::PUT])) {
+        if (!in_array($method, [Method::GET, Method::POST, Method::DELETE])) {
             throw new \InvalidArgumentException('The method is not correct');
         }
     }


### PR DESCRIPTION
The LinkedIn [Assets API](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/vector-asset-api?view=li-lms-2025-01&viewFallbackFrom=li-lms-2022-07&tabs=curl#upload-the-image) uses the PUT method to upload image assets, but the current implementation does not support it for the following reasons:

- The PUT method does not return any response body, making it incompatible with Client::api, which expects a response body.
- The Method::isMethodSupported  currently prohibits the PUT method.

Added Client::put($endpoint, $resource) to handle uploads:

Parameters:
- $endpoint (string): The API endpoint where the resource will be sent.
- $resource (resource): The data resource to be uploaded (typically a file handle).

If the provided argument is not a valid resource, it throws an InvalidArgumentException